### PR TITLE
Corrected CVE-2024-29849.py

### DIFF
--- a/CVE-2024-29849.py
+++ b/CVE-2024-29849.py
@@ -110,7 +110,7 @@ def get_cn_from_cert(target):
             break
     if cn != None:
         print(f"(*) Common Name (CN) extracted from certificate: {cn}")
-        domain_name = f"{cn.split(".")[-2]}.{cn.split(".")[-1]}"
+        domain_name = f"{cn.split('.')[-2]}.{cn.split('.')[-1]}"
         print(f"(*) Assumed domain name: {domain_name}")
         answer = input("(?) Is the assumed domain name correct(Y/n)?")
         if answer.lower() == "y":


### PR DESCRIPTION
When the file is executed, it gives an error:
line 113
    domain_name = f"{cn.split(".")[-2]}.{cn.split(".")[-1]}"
                               ^
SyntaxError: f-string: unmatched '('

I have corrected this by replacing the line 113 with: 
domain_name = f"{cn.split('.')[-2]}.{cn.split('.')[-1]}"